### PR TITLE
Make user-vhost-warning more friendly

### DIFF
--- a/www/templates/user-vhost-warning
+++ b/www/templates/user-vhost-warning
@@ -1,22 +1,24 @@
-Dear {group}:
+Hi {group},
 
-The OCF staff noticed that your group's website [1] does not have either
-the "Hosted by OCF" banner [2] or University disclaimer [3] required by OCF
-and university virtual hosting rules. All student group websites are
-required to display the "Hosted by OCF" banner as well as the student group
-disclaimer. Unfortunately, if you do not add both of them, we may be forced
-to temporarily disable your website to comply with the OCF's and
-university's requirements. Please add both sometime within the next 2 weeks
-to prevent disabling of your website.
+The staff at the OCF noticed that your group's website [1] may be missing a
+"Hosted by OCF" banner [2] or the University-mandated "student group
+disclaimer" [3]. All student group websites must display both elements to
+comply with OCF virtual hosting policy and University trademark
+regulation. If your website isn't fully compliant, we will have to
+temporarily disable it to comply with these requirements. We'll check back
+in about two weeks, so please try to make any needed changes by then.
 
 Your username is "{username}".
 
-If you've forgotten how to login, instructions can be found here [4]. If
+If you've forgotten how to log in, instructions can be found here [4]. If
 you've forgotten your password, you can reset it here [5].
 
 Feel free to reply all to this email if you have any questions or if we can
 help with making the change! Please include help@ocf.berkeley.edu if you
 would like a response.
+
+Thanks for flying OCF,
+The friendly staff of 171 MLK Student Union
 
 1. {website}
 2. https://www.ocf.berkeley.edu/docs/services/vhost/#ocf_banner

--- a/www/templates/user-vhost-warning
+++ b/www/templates/user-vhost-warning
@@ -1,10 +1,10 @@
 Hi {group},
 
-The staff at the OCF noticed that your group's website [1] may be missing a
-"Hosted by OCF" banner [2] or the University-mandated "student group
-disclaimer" [3]. All student group websites must display both elements to
-comply with OCF virtual hosting policy and University trademark
-regulation. If your website isn't fully compliant, we will have to
+The OCF volunteer staff team noticed that your group's website [1] may be
+missing a "Hosted by OCF" banner [2] or the University-mandated "student
+group disclaimer" [3]. All student group websites must display both
+elements to comply with OCF virtual hosting policy and University domain
+name policy. If your website isn't fully compliant, we will have to
 temporarily disable it to comply with these requirements. We'll check back
 in about two weeks, so please try to make any needed changes by then.
 
@@ -14,8 +14,7 @@ If you've forgotten how to log in, instructions can be found here [4]. If
 you've forgotten your password, you can reset it here [5].
 
 Feel free to reply all to this email if you have any questions or if we can
-help with making the change! Please include help@ocf.berkeley.edu if you
-would like a response.
+help with making the change!
 
 Thanks for flying OCF,
 The friendly staff of 171 MLK Student Union


### PR DESCRIPTION
Hopefully this will cut down on the number of "fuck ocf" commit messages as in [rt#6163](https://ocf.io/rt/6163).

This also sort of points to the University as the primary reason for the enforcement, even though it's only half their rules and half ours. I think people may be more willing to the make the change if they see it as University bureaucracy and not arbitrary restrictions imposed by us.