### PR TITLE
Validate templates variables have been given to copy/paste template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.tox
+/www/index.html

--- a/www/index.html.tmpl
+++ b/www/index.html.tmpl
@@ -10,7 +10,7 @@
             }
 
             input.error {
-                background-color: #fcc;
+                background-color: #f66;
                 border-color: #a94442;
             }
         </style>
@@ -46,7 +46,7 @@
 
                 var preventSelection = function(e) {
                     e.preventDefault();
-                }
+                };
 
                 function updateText() {
                     // By default, assume the variables are filled and

--- a/www/index.html.tmpl
+++ b/www/index.html.tmpl
@@ -8,6 +8,11 @@
             #variables > div {
                 margin-bottom: 10px;
             }
+
+            input.error {
+                background-color: #fcc;
+                border-color: #a94442;
+            }
         </style>
     </head>
     <body>
@@ -39,7 +44,16 @@
                     text = '',
                     values = {};
 
+                var preventSelection = function(e) {
+                    e.preventDefault();
+                }
+
                 function updateText() {
+                    // By default, assume the variables are filled and
+                    // text selection of the template is allowed
+                    $('#text').unbind('mousedown', preventSelection);
+                    $('#text').prop('readonly', false);
+
                     var content = text,
                         vars = _.map(_.uniq(content.match(/{.+?}/g)), function(str) {
                             return str.substring(1, str.length - 1);
@@ -55,10 +69,12 @@
                                 )
                                 .append(
                                     $('<input type="text">')
-                                        .addClass('form-control')
+                                        .addClass('form-control error')
                                         .val(values[v] || '')
                                         .keyup(function() {
                                             values[v] = $(this).val();
+                                            // If the field is empty, show it as errored
+                                            $(this).toggleClass('error', values[v] === "");
                                             updateText();
                                         })
                                 )
@@ -69,6 +85,14 @@
                     _.each(vars, function(v) {
                         var search = '{' + v + '}',
                             replace = values[v] || search;
+
+                        // Set the template text as not selectable and grey it
+                        // out to make it clear that not all the variables have
+                        // been filled
+                        if (!(v in values) || values[v] === "") {
+                            $('#text').bind('mousedown', preventSelection);
+                            $('#text').prop('readonly', true);
+                        }
 
                         // fuck JavaScript
                         content = content.split(search).join(replace);


### PR DESCRIPTION
The idea of this is to prevent copying the templates with variables not filled in and then regretting it later. This hasn't happened often, but I think it's a sensible thing to add so that the templates system is used correctly in the future, and it's been something I've wanted to do for a while with the templates system to make it a bit clearer to use.

Here's an example of the security-apache template with the version missing. The required variable is in red, and the text box is disabled (can't select text, and it is grayed out).

![template-validation](https://user-images.githubusercontent.com/1523594/34647260-6c8f326e-f33b-11e7-86d4-3bc53be240a2.png)

A live version is temporarily in [my userdir](https://www.ocf.berkeley.edu/~jvperrin/templates/) if you want to actually play around with it.

For future improvements, I'm thinking that adding more validation would be good as long as it's clear when it's failing validation and why. Some examples are making sure that something that is supposed to be a username actually fits the username format, same with vhosts, dates, etc.