### PR TITLE
Add new apphost upgrading template

### DIFF
--- a/www/templates/user-apphost-dist-upgrade
+++ b/www/templates/user-apphost-dist-upgrade
@@ -124,6 +124,8 @@ The timeline for this move looks like:
   server will be switched into its place, and your domain served.
 
 If you think you need more time to make the upgrade or have any questions,
-please let us know as soon as you can.
+please let us know as soon as you can. To contact us, please either reply to
+this email or come to one of our staff hours (https://ocf.io/staff-hours) to
+talk about the migration with a friendly OCF staff member!
 
 Thanks!

--- a/www/templates/user-apphost-dist-upgrade
+++ b/www/templates/user-apphost-dist-upgrade
@@ -1,0 +1,129 @@
+Hi {user},
+
+The OCF, which hosts your website {fqdn} is upgrading its app hosting
+infrastructure from Debian jessie to Debian stretch!
+
+The upgrade will happen by moving the currently running apps from the existing
+server (named werewolves) to a new server (named vampires).  You can already
+connect to the new server by using SSH and connecting to
+"vampires.ocf.berkeley.edu".
+
+Right now, your app is only running on werewolves. We need your help to get it
+moved over to vampires so that we can complete the transition to the latest
+Debian version.
+
+The versions for nearly all software installed on the system will be changing,
+which is why the migration cannot be done in a more automatic way. Some notable
+changes include:
+
+    - Ruby 2.1.5     -> Ruby 2.3.3
+    - Python 3.4.2   -> Python 3.5.3
+    - Python 2.7.9   -> Python 2.7.13
+    - NodeJS 0.10.29 -> NodeJS 4.8.2
+    - PHP 5.6.36     -> PHP 7.0.30
+
+Because binaries for programs like Ruby, Python, and NodeJS are dynamically
+linked, if you have a copy of these programs in your home directory (which is
+what programs like virtualenv, nvm, and rvm do), there is a good chance they
+won't work on the new server.
+
+In most cases, it is necessary to rebuild your environment (such as recreating
+a virtualenv on the new system or reinstalling Ruby/Node using rvm/nvm).
+
+We'd like to help you make the upgrade without downtime. The way we recommend
+this is:
+
+
+1. Log in to vampires and create a *copy* of your entire apps folder.  It won't
+   work to make a copy of the directory inside apps, you need to copy the
+   entire folder.
+
+   For example:
+
+       {user}@vampires:~$ cp -r apps apps-stretch
+
+   It's necessary to create a *new* apps folder because otherwise the systemd
+   process running on werewolves, the old app server, will try to launch your
+   new copy of the app as well and the copy of your existing app might not
+   work, causing downtime for your website.
+
+
+2. On vampires, cd into the new folder and try executing the run script:
+
+       {user}@vampires:~$ cd apps-stretch/myapp
+       {user}@vampires:~/apps-stretch/myapp$ ./run
+
+   Hopefully it'll either work, or you'll see a helpful error. If it works, you
+   can test your site at this URL to ensure it behaves as you'd expect:
+
+   https://{fqdn_with_dashes}.dev-apphost.ocf.berkeley.edu/
+
+   If you see errors, you'll have to determine how to resolve them. The
+   documentation on our website might be useful:
+   https://www.ocf.berkeley.edu/docs/services/webapps/
+
+   You can also ask for our help by replying to this email, we'd be happy to
+   help you with the migration.
+
+
+3. Copy the existing systemd service file to make a new service for the new
+   version of your app:
+
+       {user}@vampires:~$ cd ~/.config/systemd/user
+       {user}@vampires:~/.config/systemd/user$ cp myapp.service myapp-stretch.service
+
+   Then edit the systemd service file (myapp-stretch.service) and replace the
+   line that says:
+
+       ConditionHost=werewolves
+
+   with a line containing:
+
+       ConditionHost=vampires
+
+   so that your new version of your app will run only on the new server. Then,
+   enable your service so that it starts when the apphosting machine boots, and
+   start it up:
+
+       {user}@vampires:~$ systemctl --user daemon-reload
+       {user}@vampires:~$ systemctl --user enable myapp-stretch.service
+       {user}@vampires:~$ systemctl --user start myapp-stretch.service
+
+   Our docs on apphost supervising might also be helpful here if you run into
+   any issues: https://www.ocf.berkeley.edu/docs/services/webapps/#supervise
+
+   If you need any help here, also feel free to ask. We have a lot of
+   experience troubleshooting systemd service issues and we'd be happy to help
+   if you encounter any troubles.
+
+
+4. Once you've ironed out all the kinks in your app, reply to this email to let
+   us know you've upgraded. We'll switch over to the new server according to
+   the schedule listed below and your new app version will be switched over to
+   run under your domain as part of the process. You should leave the old
+   version of the app running on werewolves until the switch in servers is made
+   on {upgrade_date} to avoid any downtime.
+
+
+Please respond as soon as possible and confirm you're working on this.  If
+you'd like us to attempt to upgrade the site for you, we're happy to do that;
+just let us know.
+
+The timeline for this move looks like:
+
+- Today ({today}):
+  Notify groups about apphosting server move
+
+- {response_deadline}:
+  Deadline to respond. We need to hear from you by this date, even if it's just
+  "we're working on it". If we don't hear from you, we will assume you want us
+  to attempt to upgrade your site for you.
+
+- {upgrade_date}:
+  Deadline to upgrade. The old server will be gone after this date, the new
+  server will be switched into its place, and your domain served.
+
+If you think you need more time to make the upgrade or have any questions,
+please let us know as soon as you can.
+
+Thanks!


### PR DESCRIPTION
This is mostly copied from emails sent by @chriskuehl around Feburary 2016, but some information has been changed. For instance, back then, we were using svscan/daemontools for apphosting and have since switched to systemd, and there's different version upgrades to feature this time around.