### PR TITLE
Add templates.ocf.io redirect

### DIFF
--- a/kubernetes/templates.yml.erb
+++ b/kubernetes/templates.yml.erb
@@ -39,9 +39,20 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: virtual-host-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'templates.ocf.io') {
+        return 308 https://templates.ocf.berkeley.edu$request_uri;
+      }
 spec:
   rules:
     - host: templates.ocf.berkeley.edu
+      http:
+        paths:
+          - backend:
+              serviceName: templates-service
+              servicePort: 80
+    - host: templates.ocf.io
       http:
         paths:
           - backend:


### PR DESCRIPTION
This was the most elegant solution I could find. Using `nginx.ingress.kubernetes.io/permanent-redirect` needed a whole new ingress file. You need to specify the `http:` stuff even though nothing is actually getting sent there (see https://github.com/kubernetes/ingress-nginx/issues/1405).